### PR TITLE
Template debugger time & memory graph

### DIFF
--- a/views/toolbar.php
+++ b/views/toolbar.php
@@ -73,6 +73,7 @@ function EEDebugPanel(name)
 
     if(name == "EEDebug_memory" && !window.EEDebugGraphRendered) {
     	EEDebugGraph(name);
+    	window.EEDebugGraphRendered = true;
     }
 }
 
@@ -138,13 +139,10 @@ function EEDebugGraph(nodeName)
 
 	if(data === false) {
 		wrapper.remove();
-		window.EEDebugGraphRendered = true;
 		return;
 	}
 
 	EEDebugRefreshGraph(ctx, data);
-
-	window.EEDebugGraphRendered = true;
 }
 
 function EEDebugRefreshGraph (ctx, data) {


### PR DESCRIPTION
I've been working on a lightweight graph visualisation of the template debugging profiler.  Its powered by canvas and incorporates feature detection, so it should fail gracefully.

If you like the look of this, I can go ahead and implement it for the Database Query log.
![Screen Shot 2012-12-16 at 17 01 14](https://f.cloud.github.com/assets/163045/15631/475ff568-47a2-11e2-8154-c3580ccb91ee.png)
