### PR TITLE
fix array to string conversion notice

### DIFF
--- a/system/expressionengine/third_party/ee_debug_toolbar/ext.ee_debug_toolbar.php
+++ b/system/expressionengine/third_party/ee_debug_toolbar/ext.ee_debug_toolbar.php
@@ -260,7 +260,7 @@ class Ee_debug_toolbar_ext
 		$vars['memory_usage']                  = $this->EE->toolbar->filesize_format(memory_get_peak_usage());
 		$vars['template_debugging_enabled']    = isset($this->EE->TMPL->log) && is_array($this->EE->TMPL->log) && count($this->EE->TMPL->log) > 0;
 		$vars['template_debugging']            = ($vars['template_debugging_enabled'] ? $this->EE->toolbar->format_tmpl_log($this->EE->TMPL->log) : array());
-		$vars['template_debugging_chart_json'] = ($vars['template_debugging_enabled'] ? $this->EE->toolbar->format_tmpl_chart_json($vars['template_debugging']) : array());
+		$vars['template_debugging_chart_json'] = ($vars['template_debugging_enabled'] ? $this->EE->toolbar->format_tmpl_chart_json($vars['template_debugging']) : json_encode(array()));
 		$vars['included_file_data']            = $this->EE->toolbar->setup_files(get_included_files());
 
 		$vars['ext_version']                   = $this->version;


### PR DESCRIPTION
The default `array()` breaks the graph subpanel in the EE backend. JSON encoding fixes it. Example error message: 

```
ERROR - 2015-11-26 17:44:49 --> Severity: Notice  --> Array to string conversion /localhost/ee/app/third_party/ee_debug_toolbar/views/partials/memory.php 28
```
